### PR TITLE
Fix test issues

### DIFF
--- a/app/src/main/java/com/example/pointsapp/points/PointsViewModel.kt
+++ b/app/src/main/java/com/example/pointsapp/points/PointsViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.pointsapp.points
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pointsapp.domain.GetPoints
@@ -17,16 +16,12 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-private const val KEY_COUNT = "count"
-
 @HiltViewModel(assistedFactory = PointsViewModel.Factory::class)
 class PointsViewModel @AssistedInject constructor(
-    @Assisted count: Int,
+    @Assisted
+    private val count: Int,
     private val getPoints: GetPoints,
-    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-
-    private val count = savedStateHandle.getStateFlow(KEY_COUNT, count)
 
     private val mutableState = MutableStateFlow<PointsState>(PointsState.Initial)
     val state: StateFlow<PointsState> = mutableState
@@ -41,7 +36,7 @@ class PointsViewModel @AssistedInject constructor(
     private fun loadPoints() {
         viewModelScope.launch {
             mutableState.value = PointsState.Loading
-            getPoints(count.value)
+            getPoints(count)
                 .onSuccess { points ->
                     mutableState.value = PointsState.Content(points)
                 }

--- a/app/src/test/java/com/example/pointsapp/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/example/pointsapp/main/MainViewModelTest.kt
@@ -22,10 +22,10 @@ class MainViewModelTest {
 
     @Test
     fun `lets go is enabled when count is set to positive number`() = runTest {
-        viewModel.onCountChanged(10)
-
         viewModel.letsGoEnabled.test {
-            skipItems(1)
+            viewModel.onCountChanged(10)
+            awaitItem()
+
             assertTrue(awaitItem())
         }
     }

--- a/app/src/test/java/com/example/pointsapp/points/PointsViewModelTest.kt
+++ b/app/src/test/java/com/example/pointsapp/points/PointsViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.example.pointsapp.points
 
-import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.example.pointsapp.domain.GetPoints
@@ -14,7 +13,6 @@ import org.junit.Test
 class PointsViewModelTest {
 
     private val testCount = 5
-    private val testSavedStateHandle = SavedStateHandle()
     private val testPoints = listOf(
         Point(1.0, 1.0),
         Point(2.0, 2.0),
@@ -33,7 +31,6 @@ class PointsViewModelTest {
                     }
                 }
             ),
-            savedStateHandle = testSavedStateHandle,
         )
 
         val actual = viewModel.state.value
@@ -53,7 +50,6 @@ class PointsViewModelTest {
                     }
                 }
             ),
-            savedStateHandle = testSavedStateHandle,
         )
 
         turbineScope {
@@ -78,7 +74,6 @@ class PointsViewModelTest {
                     }
                 }
             ),
-            savedStateHandle = testSavedStateHandle,
         )
 
         turbineScope {
@@ -102,7 +97,6 @@ class PointsViewModelTest {
                     }
                 }
             ),
-            savedStateHandle = testSavedStateHandle,
         )
 
         viewModel.events.test {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the `PointsViewModel` and its tests by removing unnecessary dependencies and simplifying the code structure. It also updates a test in `MainViewModelTest` for better clarity.

### Detailed summary
- In `MainViewModelTest.kt`, `onCountChanged(10)` is now awaited before asserting `letsGoEnabled`.
- In `PointsViewModelTest.kt`, removed `testSavedStateHandle` as a parameter in the `PointsViewModel` constructor.
- In `PointsViewModel.kt`, `count` is now directly assigned from the constructor instead of using `SavedStateHandle`.
- Updated `getPoints` method to use `count` directly instead of `count.value`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->